### PR TITLE
Use Azurite storage emulator for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,8 @@ after_success:
   - ./gradlew jacocoTestReport
   - bash <(curl -s https://codecov.io/bash)
 #  - test "$TRAVIS_BRANCH" = "master" && test "$TRAVIS_PULL_REQUEST" = "false" && sh ./publish-swagger-docs.sh
+
+sudo: required
+
+services:
+  - docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ before_install:
 #  - curl https://raw.githubusercontent.com/hmcts/reform-api-docs/master/bin/publish-swagger-docs.sh > publish-swagger-docs.sh
 
 script:
-  - ./gradlew test
-  - ./gradlew integration
+  - ./gradlew test -i
+  - ./gradlew integration -i
 
 after_success:
   - ./gradlew jacocoTestReport

--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,9 @@ repositories {
   maven {
     url "https://repo.spring.io/libs-milestone"
   }
+    maven {
+      url 'https://dl.bintray.com/palantir/releases' // docker-compose-rule is published on bintray
+    }
 }
 
 // it is important to specify logback classic and core packages explicitly as libraries like spring boot
@@ -166,6 +169,8 @@ dependencies {
   compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-netflix-hystrix-dashboard', version: versions.springHystrix
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot
+  testCompile group: 'com.palantir.docker.compose', name: 'docker-compose-rule-junit4', version: '0.32.0'
+
 
   integrationTestCompile sourceSets.main.runtimeClasspath
   integrationTestCompile sourceSets.test.runtimeClasspath

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanning/features/AzuriteTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanning/features/AzuriteTest.java
@@ -14,15 +14,14 @@ import java.security.InvalidKeyException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SasTest {
-
-    public static final String storageConnectionString = "UseDevelopmentStorage=true";
+public class AzuriteTest {
 
     @ClassRule
     public static DockerComposeRule docker = DockerComposeRule.builder()
         .file("src/integrationTest/resources/docker-compose.yml")
         .build();
-    CloudBlobContainer root;
+
+    private CloudBlobContainer root;
 
     @Before
     public void setup() throws URISyntaxException, InvalidKeyException, StorageException {

--- a/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanning/features/SasTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/bulkscanning/features/SasTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.bulkscanning.features;
+
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
+import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.palantir.docker.compose.DockerComposeRule;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SasTest {
+
+    public static final String storageConnectionString = "UseDevelopmentStorage=true";
+
+    @ClassRule
+    public static DockerComposeRule docker = DockerComposeRule.builder()
+        .file("src/integrationTest/resources/docker-compose.yml")
+        .build();
+    CloudBlobContainer root;
+
+    @Before
+    public void setup() throws URISyntaxException, InvalidKeyException, StorageException {
+        CloudStorageAccount account = CloudStorageAccount.parse("UseDevelopmentStorage=true");
+        CloudBlobClient serviceClient = account.createCloudBlobClient();
+
+        root = serviceClient.getContainerReference("incoming");
+        root.createIfNotExists();
+    }
+
+    @Test
+    public void testAzuriteIntegration() throws URISyntaxException, InvalidKeyException, StorageException {
+        assertThat(root.exists()).isTrue();
+    }
+}

--- a/src/integrationTest/resources/docker-compose.yml
+++ b/src/integrationTest/resources/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  azure-storage:
+    image: arafato/azurite:2.6.3
+    ports:
+        - 10000:10000
+    environment:
+        - executable=blob


### PR DESCRIPTION
### Change description ###

Azurite is an open source emulator for Azure storage, that provides
docker images.

This change uses the Palantir docker-compose-rule for JUnit to start
and stop Azurite during tests, adding a single test to verify the
integration.
