### PR TITLE
Let services use separate containers

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -54,4 +54,6 @@ resource "azurerm_storage_container" "sscs" {
   resource_group_name   = "${azurerm_resource_group.rg.name}"
   storage_account_name  = "${azurerm_storage_account.provider.name}"
   container_access_type = "private"
+
+  depends_on = ["azurerm_storage_account.provider"]
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -21,7 +21,6 @@ module "backend" {
   app_settings = {
     STORAGE_ACCOUNT_NAME   = "${azurerm_storage_account.provider.name}"
     STORAGE_KEY            = "${azurerm_storage_account.provider.primary_access_key}"
-    STORAGE_CONTAINER_NAME = "${azurerm_storage_container.incoming.name}"
   }
 }
 
@@ -48,8 +47,8 @@ resource "azurerm_storage_account" "provider" {
   account_replication_type = "LRS"
 }
 
-resource "azurerm_storage_container" "incoming" {
-  name                  = "incoming"
+resource "azurerm_storage_container" "sscs" {
+  name                  = "sscs"
   resource_group_name   = "${azurerm_resource_group.rg.name}"
   storage_account_name  = "${azurerm_storage_account.provider.name}"
   container_access_type = "private"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -40,12 +40,13 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_storage_account" "provider" {
-  name                     = "bulkscanning${var.env}"
-  resource_group_name      = "${azurerm_resource_group.rg.name}"
-  location                 = "${var.location}"
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  account_kind             = "BlobStorage"
+  name                      = "bulkscanning${var.env}"
+  resource_group_name       = "${azurerm_resource_group.rg.name}"
+  location                  = "${var.location}"
+  account_tier              = "Standard"
+  account_replication_type  = "LRS"
+  account_kind              = "BlobStorage"
+  enable_https_traffic_only = true
 }
 
 resource "azurerm_storage_container" "sscs" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -45,6 +45,7 @@ resource "azurerm_storage_account" "provider" {
   location                 = "${var.location}"
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  account_kind             = "BlobStorage"
 }
 
 resource "azurerm_storage_container" "sscs" {

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/config/StorageConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.bulkscanning.config;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageCredentials;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,5 +24,10 @@ public class StorageConfiguration {
     @Bean
     public CloudStorageAccount getCloudStorageAccount(StorageCredentials storageCredentials) throws URISyntaxException {
         return new CloudStorageAccount(storageCredentials, true);
+    }
+
+    @Bean
+    public CloudBlobClient getCloudBlobClient(CloudStorageAccount account) {
+        return account.createCloudBlobClient();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/config/StorageConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/config/StorageConfiguration.java
@@ -3,8 +3,6 @@ package uk.gov.hmcts.reform.bulkscanning.config;
 import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.StorageCredentials;
 import com.microsoft.azure.storage.StorageCredentialsAccountAndKey;
-import com.microsoft.azure.storage.StorageException;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,13 +23,5 @@ public class StorageConfiguration {
     @Bean
     public CloudStorageAccount getCloudStorageAccount(StorageCredentials storageCredentials) throws URISyntaxException {
         return new CloudStorageAccount(storageCredentials, true);
-    }
-
-    @Bean
-    public CloudBlobContainer getCloudBlobContainer(
-        CloudStorageAccount account,
-        @Value("${storage.container_name}") String containerName
-    ) throws URISyntaxException, StorageException {
-        return account.createCloudBlobClient().getContainerReference(containerName);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/info/BlobContainerInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/info/BlobContainerInfoContributor.java
@@ -1,39 +1,31 @@
 package uk.gov.hmcts.reform.bulkscanning.info;
 
-import com.google.common.collect.ImmutableMap;
-
-import com.microsoft.azure.storage.StorageException;
+import com.microsoft.azure.storage.CloudStorageAccount;
+import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.info.Info.Builder;
 import org.springframework.boot.actuate.info.InfoContributor;
 import org.springframework.stereotype.Component;
 
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
 @Component
 public class BlobContainerInfoContributor implements InfoContributor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(BlobContainerInfoContributor.class);
-    private final CloudBlobContainer container;
+    private final CloudBlobClient account;
 
-    public BlobContainerInfoContributor(CloudBlobContainer container) {
-        this.container = container;
+    public BlobContainerInfoContributor(CloudStorageAccount account) {
+        this.account = account.createCloudBlobClient();
     }
 
     @Override
     public void contribute(Builder builder) {
-        builder.withDetails(ImmutableMap.of(
-            "container_name", container.getName(),
-            "container_exists", doesContainerExist()
-        ));
-    }
-
-    private boolean doesContainerExist() {
-        try {
-            return container.exists();
-        } catch (StorageException e) {
-            LOGGER.warn("Could not check if container exists", e);
-            return false;
-        }
+        builder.withDetail(
+            "containers",
+            StreamSupport.stream(account.listContainers().spliterator(), false)
+                .map(CloudBlobContainer::getName)
+                .collect(Collectors.toList())
+        );
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/bulkscanning/info/BlobContainerInfoContributor.java
+++ b/src/main/java/uk/gov/hmcts/reform/bulkscanning/info/BlobContainerInfoContributor.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.bulkscanning.info;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
 import com.microsoft.azure.storage.blob.CloudBlobClient;
 import com.microsoft.azure.storage.blob.CloudBlobContainer;
 import org.springframework.boot.actuate.info.Info.Builder;
@@ -13,17 +12,17 @@ import java.util.stream.StreamSupport;
 @Component
 public class BlobContainerInfoContributor implements InfoContributor {
 
-    private final CloudBlobClient account;
+    private final CloudBlobClient client;
 
-    public BlobContainerInfoContributor(CloudStorageAccount account) {
-        this.account = account.createCloudBlobClient();
+    public BlobContainerInfoContributor(CloudBlobClient client) {
+        this.client = client;
     }
 
     @Override
     public void contribute(Builder builder) {
         builder.withDetail(
             "containers",
-            StreamSupport.stream(account.listContainers().spliterator(), false)
+            StreamSupport.stream(client.listContainers().spliterator(), false)
                 .map(CloudBlobContainer::getName)
                 .collect(Collectors.toList())
         );

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,4 +18,3 @@ info:
 storage:
   account_name: ${STORAGE_ACCOUNT_NAME}
   key: ${STORAGE_KEY}
-  container_name: ${STORAGE_CONTAINER_NAME:incoming}

--- a/src/smokeTest/java/uk/gov/hmcts/reform/bulkscanning/WhenApplicationDeployedTest.java
+++ b/src/smokeTest/java/uk/gov/hmcts/reform/bulkscanning/WhenApplicationDeployedTest.java
@@ -7,7 +7,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.emptyArray;
+import static org.hamcrest.Matchers.not;
 
 @RunWith(SpringRunner.class)
 @TestPropertySource("classpath:application.yaml")
@@ -24,6 +25,6 @@ public class WhenApplicationDeployedTest {
             .baseUri(testUrl)
             .get("/info")
             .then()
-            .body("container_exists", equalTo(true));
+            .body("containers", not(emptyArray()));
     }
 }


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RPE-511

Each service will have its own container so that documents will not be
mixed up. A container is named after the service it was provided for.

`STORAGE_CONTAINER_NAME` variable is removed as names are read from
storage account.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
