### PR TITLE
Use product variable in storage account name

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -6,6 +6,8 @@ provider "vault" {
 
 locals {
   app = "bulk-scanning"
+  base_account_name = "${var.product}bulkscan${var.env}"
+  account_name = "${replace(local.base_account_name, "-", "")}"
 }
 
 module "backend" {
@@ -40,7 +42,7 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_storage_account" "provider" {
-  name                      = "bulkscanning${var.env}"
+  name                      = "${substr(local.account_name, 0, 24)}"
   resource_group_name       = "${azurerm_resource_group.rg.name}"
   location                  = "${var.location}"
   account_tier              = "Standard"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -42,7 +42,7 @@ resource "azurerm_resource_group" "rg" {
 }
 
 resource "azurerm_storage_account" "provider" {
-  name                      = "${substr(local.account_name, 0, 24)}"
+  name                      = "${substr(local.account_name, 0, min(length(local.account_name), 24))}"
   resource_group_name       = "${azurerm_resource_group.rg.name}"
   location                  = "${var.location}"
   account_tier              = "Standard"


### PR DESCRIPTION
Builds are failing due to error returned from Azure with code
`StorageAccountAlreadyExists`. After deleting the resources the build
can be re-ran.

Each build implicitly is given information about pull request number
that is included in `product` variable. It follows `pr-{number}-rpe`
scheme.

Solution to the error is to include `product` value in the storage
account name. To make it more challenging, Azure has certain limitations
for account naming:

 - length between 3 and 24 characters
 - alphanumerics only

Because of that, any dashes in `product` value have to be removed, and
the final value has to be trimmed down to 24 characters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
